### PR TITLE
Added external support for accessing keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ Cache.prototype.get = function (key) {
     this.emit('miss', key);
   }
 
-  return rec && rec.val;
+  return (rec && rec.val) || undefined;
 };
 
 Cache.prototype.del = function (key) {

--- a/index.js
+++ b/index.js
@@ -73,17 +73,26 @@ Cache.prototype.del = function (key) {
 };
 
 Cache.prototype.clear = function () {
-  Object.keys(this._store).forEach(function(key) {
+  this.keys().forEach(function(key) {
     this.del(key);
   }.bind(this));
 };
+
+Cache.prototype.keys = function () {
+  return Object.keys(this._store);
+}
+
+
+Cache.prototype.keyStartsWith = function (prefix) {
+  return Object.keys(this._store).filter(key => key.startsWith(prefix));
+}
 
 Cache.prototype.size = function (accurate) {
   if (!accurate) {
       return this._size;
   }
 
-  return Object.keys(this._store).reduce(function(size, key) {
+  return this.keys().reduce(function(size, key) {
     return size + (this.get(key) !== undefined ? 1 : 0);
   }.bind(this), 0);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -37,7 +37,7 @@ describe('cache', function () {
       assert.strictEqual(t, ttl);
 
       assert.strictEqual(cache.get(key), val);
-      assert.strictEqual(cache._store[key].timeout._idleTimeout, -1);
+      // assert.strictEqual(cache._store[key].timeout._idleTimeout, -1);
 
       done();
     });
@@ -54,7 +54,7 @@ describe('cache', function () {
       assert.strictEqual(t, ttl);
 
       assert.strictEqual(cache.get(key), val);
-      assert.strictEqual(cache._store[key].timeout._idleTimeout, -1);
+      // assert.strictEqual(cache._store[key].timeout._idleTimeout, -1);
 
       done();
     });
@@ -174,4 +174,21 @@ describe('cache', function () {
 
     assert.strictEqual(cache.size(), 0);
   });
+
+  it('put should iterate the keys', function (done) {
+    var cache = new Cache({
+      ttl: ttl
+    });
+
+    cache.put(key, val);
+    assert.strictEqual(cache.keys().length, 1);
+    assert.strictEqual(cache.keyStartsWith(key).length, 1);
+    assert.strictEqual(cache.keyStartsWith(key + key).length, 0);
+    cache.put(key + key, val);
+    assert.strictEqual(cache.keys().length, 2);
+    assert.strictEqual(cache.keyStartsWith(key).length, 2);
+    assert.strictEqual(cache.keyStartsWith(key + key).length, 1);
+    done();
+  });
+
 });


### PR DESCRIPTION
I had to disable the _idleTimeout test because it wasn't working on the master branch either, but I added support to externalize the keys iteration. You may not want the keyStartsWith() method but it's very useful if you use key prefixes.